### PR TITLE
Fix incorrect tag name in galaxy file

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,7 +13,6 @@ tags:
   - "python"
   - "venv"
   - "virtualenv"
-  - "virtual environment"
   - "docker"
   - "docker-compose"
 repository: "https://github.com/hoodnoah/homelab_provisioning"


### PR DESCRIPTION
This pull request fixes an incorrect tag name in the galaxy.yml file. The tag "virtual environment" has been removed.