### PR TITLE
Fix incorrect tag name in galaxy file

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -14,5 +14,11 @@ tags:
   - "venv"
   - "virtualenv"
   - "docker"
-  - "docker-compose"
+  - "docker_compose"
 repository: "https://github.com/hoodnoah/homelab_provisioning"
+build_ignore:
+  - "venv"
+  - ".gitignore"
+  - ".github"
+  - "*.tar.gz"
+  - "*.json"


### PR DESCRIPTION
This pull request fixes the incorrect tag name in the galaxy.yml file. The tag "docker-compose" has been changed to "docker_compose".