### PR TITLE
Add get_uid_gid role and update readme + galaxy.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This collection includes roles which are common tasks across many hosts on my ho
 ## Roles
 
 - [bootstrap_docker](roles/bootstrap_docker/README.md): A role for installing/ensuring Docker is installed and operational.
+- [get_uid_gid](roles/get_uid_gid/README.md): A role for collecting the current user's UID and GID, for injection into [Linuxserver's Docker-Compose images](https://docs.linuxserver.io/general/understanding-puid-and-pgid/).
 
 ## Requirements
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,13 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2024-01-10
+## [2.1.0] - 2024-01-12
 
 ### Added
 
-- Role for setting up a Python virtual environment, for ansible to use
-- Role for setting up Docker on a host system, dependent on the above Python role
-- Setup automatic deployment to `ansible-galaxy` on `release`.
+- `get_uid_gid` role for registering the current user's uid, gid into `PUID` and `PGID` facts, respectively.
 
 ## [2.0.0] - 2024-01-11
 
@@ -26,3 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Python role due to aforementioned obviation of python dependency in `community.docker` collection
 - Python package installation in docker installation role
+
+## [1.0.0] - 2024-01-10
+
+### Added
+
+- Role for setting up a Python virtual environment, for ansible to use
+- Role for setting up Docker on a host system, dependent on the above Python role
+- Setup automatic deployment to `ansible-galaxy` on `release`.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: "hoodnoah"
 name: "homelab_provisioning"
 description: "Ansible roles for tasks common across hosts for provisioning my homelab"
-version: "2.0.0"
+version: "2.1.0"
 readme: "README.md"
 authors:
   - "Noah Hood <hood.noah@icloud.com>"

--- a/roles/get_uid_gid/README.md
+++ b/roles/get_uid_gid/README.md
@@ -1,0 +1,34 @@
+# Role Name
+
+Collects the UID, GID of the current user, storing them in the facts `PUID` and `PGID`, respectively.
+
+## Facts
+
+- `puid`: The UID of the current user.
+- `pgid`: The GID of the current user.
+
+## Requirements
+
+None.
+
+## Role Variables
+
+None.
+
+## Dependencies
+
+None.
+
+## Example Playbook
+
+    - hosts: servers
+      roles:
+         - { role: hoodnoah.homelab_provisioning.get_uid_gid }
+
+## License
+
+MIT
+
+## Author Information
+
+Noah Hood [hood.noah@icloud.com](mailto:hood.noah@icloud.com)

--- a/roles/get_uid_gid/defaults/main.yml
+++ b/roles/get_uid_gid/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file for ./roles/get_uid_gid

--- a/roles/get_uid_gid/handlers/main.yml
+++ b/roles/get_uid_gid/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for ./roles/get_uid_gid

--- a/roles/get_uid_gid/meta/main.yml
+++ b/roles/get_uid_gid/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: your name
+  description: your role description
+  company: your company (optional)
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: license (GPL-2.0-or-later, MIT, etc)
+
+  min_ansible_version: 2.1
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/get_uid_gid/tasks/main.yml
+++ b/roles/get_uid_gid/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+# tasks file for ./roles/get_uid_gid
+- name: Get user
+  ansible.builtin.command:
+    cmd: whoami
+  register: CURRENT_USER
+
+- name: Get UID and GID
+  ansible.builtin.getent:
+    database: passwd
+    key: "{{ CURRENT_USER.stdout }}"
+  register: USER_INFO
+
+- name: Set uid and gid facts
+  set_fact:
+    puid: "{{ USER_INFO.ansible_facts.getent_passwd[CURRENT_USER.stdout].1 }}"
+    pgid: "{{ USER_INFO.ansible_facts.getent_passwd[CURRENT_USER.stdout].2 }}"

--- a/roles/get_uid_gid/tests/inventory
+++ b/roles/get_uid_gid/tests/inventory
@@ -1,0 +1,2 @@
+localhost
+

--- a/roles/get_uid_gid/tests/test.yml
+++ b/roles/get_uid_gid/tests/test.yml
@@ -1,0 +1,5 @@
+---
+- hosts: localhost
+  remote_user: root
+  roles:
+    - ./roles/get_uid_gid

--- a/roles/get_uid_gid/vars/main.yml
+++ b/roles/get_uid_gid/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for ./roles/get_uid_gid


### PR DESCRIPTION
This pull request adds the get_uid_gid role, which collects the UID and GID of the current user and stores them in the facts PUID and PGID. It also updates the readme and galaxy.yml files to reflect the changes.