### PR TITLE
Fix casing of PUID and PGID variables

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2023-01-12
+
+### Fixed
+
+- `get_uid_gid` role now sets `PUID` and `PGID` in uppercase, rather than lowercase.
+
 ## [2.1.0] - 2024-01-12
 
 ### Added

--- a/roles/get_uid_gid/tasks/main.yml
+++ b/roles/get_uid_gid/tasks/main.yml
@@ -13,5 +13,5 @@
 
 - name: Set uid and gid facts
   set_fact:
-    puid: "{{ USER_INFO.ansible_facts.getent_passwd[CURRENT_USER.stdout].1 }}"
-    pgid: "{{ USER_INFO.ansible_facts.getent_passwd[CURRENT_USER.stdout].2 }}"
+    PUID: "{{ USER_INFO.ansible_facts.getent_passwd[CURRENT_USER.stdout].1 }}"
+    PGID: "{{ USER_INFO.ansible_facts.getent_passwd[CURRENT_USER.stdout].2 }}"


### PR DESCRIPTION
This pull request fixes the casing of the PUID and PGID variables in the `get_uid_gid` role. Previously, the variables were set in lowercase, but now they are set in uppercase. This ensures consistency and avoids any potential issues caused by incorrect casing.