### PR TITLE
Update version number to 2.1.1

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: "hoodnoah"
 name: "homelab_provisioning"
 description: "Ansible roles for tasks common across hosts for provisioning my homelab"
-version: "2.1.0"
+version: "2.1.1"
 readme: "README.md"
 authors:
   - "Noah Hood <hood.noah@icloud.com>"


### PR DESCRIPTION
This pull request updates the version number in the galaxy.yml file to 2.1.1. This is necessary to reflect the latest changes and improvements made to the Ansible roles for provisioning my homelab.