### PR TITLE
Fix unnecessary logging in Docker-Compose up step

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2023-01-13
+
+### Fixed
+
+- Hid Docker-Compose output to prevent `community.docker.docker_compose_v2` from polluting logs w/ warnings about output parsing
+
 ## [2.1.1] - 2023-01-12
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: "hoodnoah"
 name: "homelab_provisioning"
 description: "Ansible roles for tasks common across hosts for provisioning my homelab"
-version: "2.1.1"
+version: "2.1.2"
 readme: "README.md"
 authors:
   - "Noah Hood <hood.noah@icloud.com>"

--- a/roles/bootstrap_docker/tasks/main.yml
+++ b/roles/bootstrap_docker/tasks/main.yml
@@ -73,6 +73,7 @@
     community.docker.docker_compose_v2:
       project_src: /tmp/hello-world
       state: present
+    register: output
   - name: Tear stack back down
     community.docker.docker_compose_v2:
       project_src: /tmp/hello-world


### PR DESCRIPTION
This pull request fixes the issue of unnecessary logging in the Docker-Compose up step. It hides the Docker-Compose output to prevent the `community.docker.docker_compose_v2` module from polluting the logs with warnings about output parsing.