### PR TITLE
Add early-exit for Docker configuration

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.3] - 2023-01-13
+
+- Added registration of docker installation to permit early-exit in the event docker has already been verified once in the playbook run
+
 ## [2.1.2] - 2023-01-13
 
 ### Fixed

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: "hoodnoah"
 name: "homelab_provisioning"
 description: "Ansible roles for tasks common across hosts for provisioning my homelab"
-version: "2.1.2"
+version: "2.1.3"
 readme: "README.md"
 authors:
   - "Noah Hood <hood.noah@icloud.com>"

--- a/roles/bootstrap_docker/tasks/main.yml
+++ b/roles/bootstrap_docker/tasks/main.yml
@@ -2,6 +2,10 @@
 # tasks file for docker
 - name: Setup Docker
   block:
+    - name: Exit early if docker is already installed
+      meta: end_host
+      when: DOCKER_CONFIGURED is defined and DOCKER_CONFIGURED
+
     - name: Install Docker dependencies
       apt:
         name: "{{ item }}"
@@ -82,3 +86,7 @@
     ansible.builtin.file:
       path: /tmp/hello-world
       state: absent
+
+- name: Set DOCKER_CONFIGURED fact
+  ansible.builtin.set_fact:
+    DOCKER_CONFIGURED: true


### PR DESCRIPTION
This pull request adds an early-exit feature to the Docker configuration process. It includes a new task that checks if Docker is already installed and exits the playbook if it is. This optimization improves the efficiency of the provisioning process.