### PR TITLE
Fix early exit issue in docker role

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.4] - 2023-01-13
+
+- Fixed early exit to permit processing of other tasks subsequent to the `bootstrap_docker` role
+
 ## [2.1.3] - 2023-01-13
 
 - Added registration of docker installation to permit early-exit in the event docker has already been verified once in the playbook run

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,7 +2,7 @@
 namespace: "hoodnoah"
 name: "homelab_provisioning"
 description: "Ansible roles for tasks common across hosts for provisioning my homelab"
-version: "2.1.3"
+version: "2.1.4"
 readme: "README.md"
 authors:
   - "Noah Hood <hood.noah@icloud.com>"

--- a/roles/bootstrap_docker/tasks/main.yml
+++ b/roles/bootstrap_docker/tasks/main.yml
@@ -2,10 +2,6 @@
 # tasks file for docker
 - name: Setup Docker
   block:
-    - name: Exit early if docker is already installed
-      meta: end_host
-      when: DOCKER_CONFIGURED is defined and DOCKER_CONFIGURED
-
     - name: Install Docker dependencies
       apt:
         name: "{{ item }}"
@@ -43,6 +39,7 @@
         name: docker
         state: started
         enabled: yes
+  when: DOCKER_CONFIGURED is not defined or not DOCKER_CONFIGURED
 
 - name: Setup users, groups
   block:
@@ -56,6 +53,7 @@
         name: "{{ default_uname }}"
         groups: docker
         append: yes
+  when: DOCKER_CONFIGURED is not defined or not DOCKER_CONFIGURED
 
 - name: Run hello-world test
   block:
@@ -86,7 +84,9 @@
     ansible.builtin.file:
       path: /tmp/hello-world
       state: absent
+  when: DOCKER_CONFIGURED is not defined or not DOCKER_CONFIGURED
 
 - name: Set DOCKER_CONFIGURED fact
   ansible.builtin.set_fact:
     DOCKER_CONFIGURED: true
+  when: DOCKER_CONFIGURED is not defined or not DOCKER_CONFIGURED


### PR DESCRIPTION
This pull request fixes the early exit issue in the docker role. Previously, the role would exit early if docker was already installed, preventing other tasks from being processed. This PR removes the early exit condition, allowing downstream tasks to be processed regardless of whether docker is already installed.